### PR TITLE
Update README to switch from person.proto to Example.proto, since protob...

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ http://clojars.org/protobuf and http://clojars.org/lein-protobuf.
 
 ## Usage
 
-Assuming you have the following in `resources/proto/person.proto`:
+Assuming you have the following in `resources/proto/Example.proto`:
 
 ```proto
 message Person {


### PR DESCRIPTION
...uf uses the file name as the outer class
