### PR TITLE
Removed flatland/io require from protobuf codec

### DIFF
--- a/src/flatland/protobuf/codec.clj
+++ b/src/flatland/protobuf/codec.clj
@@ -5,8 +5,7 @@
         [flatland.useful.fn :only [fix]]
         [flatland.useful.experimental :only [lift-meta]]
         [clojure.java.io :only [input-stream]])
-  (:require flatland.io.core
-            [flatland.schematic.core :as schema]
+  (:require [flatland.schematic.core :as schema]
             [gloss.core :as gloss]))
 
 (declare protobuf-codec)


### PR DESCRIPTION
It seems to be unused and causes runtime errors when using codec as
flatland/io is only dev-dependency in this project.
