### PR TITLE
add size functions and more serialization/deserialization options

### DIFF
--- a/src/flatland/protobuf/PersistentProtocolBufferMap.java
+++ b/src/flatland/protobuf/PersistentProtocolBufferMap.java
@@ -173,6 +173,10 @@ public class PersistentProtocolBufferMap extends APersistentMap implements IObj 
       return DynamicMessage.parseFrom(type, input);
     }
 
+    public DynamicMessage parseFrom(InputStream input) throws IOException {
+        return DynamicMessage.parseFrom(type, input);
+    }
+
     public DynamicMessage.Builder parseDelimitedFrom(InputStream input) throws IOException {
       DynamicMessage.Builder builder = newBuilder();
       if (builder.mergeDelimitedFrom(input)) {
@@ -305,6 +309,18 @@ public class PersistentProtocolBufferMap extends APersistentMap implements IObj 
     return new PersistentProtocolBufferMap(null, def, message);
   }
 
+  static public PersistentProtocolBufferMap parseFrom(Def def, InputStream input)
+          throws IOException {
+    DynamicMessage message = def.parseFrom(input);
+    return new PersistentProtocolBufferMap(null, def, message);
+  }
+
+  static public PersistentProtocolBufferMap parseFrom(Def def, byte[] input)
+          throws IOException {
+    DynamicMessage message = def.parseFrom(input);
+    return new PersistentProtocolBufferMap(null, def, message);
+  }
+
   static public PersistentProtocolBufferMap parseDelimitedFrom(Def def, InputStream input)
           throws IOException {
     DynamicMessage.Builder builder = def.parseDelimitedFrom(input);
@@ -361,12 +377,25 @@ public class PersistentProtocolBufferMap extends APersistentMap implements IObj 
     return message().toByteArray();
   }
 
+  public void writeTo(OutputStream output) throws IOException {
+    message().writeTo(output);
+  }
+
   public void writeTo(CodedOutputStream output) throws IOException {
     message().writeTo(output);
   }
 
   public void writeDelimitedTo(OutputStream output) throws IOException {
     message().writeDelimitedTo(output);
+  }
+
+  public int getSerializedSize() {
+    return message().getSerializedSize();
+  }
+
+  public int getDelimitedSize() {
+      int serializedSize = getSerializedSize();
+      return CodedOutputStream.computeRawVarint32Size(serializedSize) + serializedSize;
   }
 
   public Descriptors.Descriptor getMessageType() {

--- a/src/flatland/protobuf/core.clj
+++ b/src/flatland/protobuf/core.clj
@@ -104,3 +104,18 @@
   "Get value at key ignoring extension fields."
   [^PersistentProtocolBufferMap p key]
   (.getValAt p key false))
+
+(defn serialized-size
+  "Get the number of bytes required to encode this message.  The result is only
+  computed on the first call and memoized after that."
+  [^PersistentProtocolBufferMap p]
+  (when p
+    (.getSerializedSize p)))
+
+(defn delimited-size
+  "Get the number of bytes required to encode this message with a length
+   delimiter.  The result is only computed on the first call and memoized after
+   that."
+  [^PersistentProtocolBufferMap p]
+  (when p
+    (.getDelimitedSize p)))


### PR DESCRIPTION
Adds `serialized-size` and `delimited-size` functions to the core namespace, as well as the associated getters in PersistentProtocolBufferMap.  Adds more serializing and parsing options to PersistentProtocolBufferMap (serializing to OutputStream, deserializing from InputStream and byte[]).
